### PR TITLE
5 restaurant rejects order

### DIFF
--- a/API.Tests/OrderStatusControllerTest.cs
+++ b/API.Tests/OrderStatusControllerTest.cs
@@ -97,6 +97,7 @@ namespace Order_status.Tests.API.Controllers
 
         [Theory]
         [InlineData(Status.Accepted)]
+        [InlineData(Status.Rejected)]
         [InlineData(Status.BeingPrepared)]
         [InlineData(Status.ReadyForPickUp)]
         [InlineData(Status.PickedUp)]
@@ -122,6 +123,7 @@ namespace Order_status.Tests.API.Controllers
 
         [Theory]
         [InlineData(Status.Accepted)]
+        [InlineData(Status.Rejected)]
         [InlineData(Status.BeingPrepared)]
         [InlineData(Status.ReadyForPickUp)]
         [InlineData(Status.PickedUp)]

--- a/API.Tests/OrderStatusServiceTest.cs
+++ b/API.Tests/OrderStatusServiceTest.cs
@@ -156,6 +156,7 @@ namespace Order_status.Tests.API.Controllers
 
         [Theory]
         [InlineData(Status.Accepted)]
+        [InlineData(Status.Rejected)]
         [InlineData(Status.BeingPrepared)]
         [InlineData(Status.ReadyForPickUp)]
         [InlineData(Status.PickedUp)]
@@ -183,6 +184,7 @@ namespace Order_status.Tests.API.Controllers
 
         [Theory]
         [InlineData(Status.Accepted)]
+        [InlineData(Status.Rejected)]
         [InlineData(Status.BeingPrepared)]
         [InlineData(Status.ReadyForPickUp)]
         [InlineData(Status.PickedUp)]
@@ -208,6 +210,7 @@ namespace Order_status.Tests.API.Controllers
 
         [Theory]
         [InlineData(Status.Accepted)]
+        [InlineData(Status.Rejected)]
         [InlineData(Status.BeingPrepared)]
         [InlineData(Status.ReadyForPickUp)]
         [InlineData(Status.PickedUp)]

--- a/Order_status.Domain/Entities/Status.cs
+++ b/Order_status.Domain/Entities/Status.cs
@@ -3,6 +3,7 @@
     public enum Status
     {
         Accepted,
+        Rejected,
         BeingPrepared,
         ReadyForPickUp,
         PickedUp, 

--- a/Order_status.Domain/Entities/StatusDescriptionHelper.cs
+++ b/Order_status.Domain/Entities/StatusDescriptionHelper.cs
@@ -9,6 +9,7 @@ namespace Order_status.Domain.Entities
             return status switch
             {
                 Status.Accepted => "Your order has been accepted by the restaurant",
+                Status.Rejected => "Unfortunately, the restaurant cannot fulfil your order at this time. Please try one of our many other delicious restaurants!",
                 Status.BeingPrepared => "Your food is being prepared",
                 Status.ReadyForPickUp => "An order is ready for pickup",
                 Status.PickedUp => "Your order has been picked up",

--- a/Order_status.UnitTests/Helpers/StatusTestData.cs
+++ b/Order_status.UnitTests/Helpers/StatusTestData.cs
@@ -8,6 +8,7 @@ namespace Order_status.UnitTests.Helpers
         public IEnumerator<object[]> GetEnumerator()
         {
             yield return new object[] { Status.Accepted, "Your order has been accepted by the restaurant" };
+            yield return new object[] { Status.Rejected, "Unfortunately, the restaurant cannot fulfil your order at this time. Please try one of our many other delicious restaurants!" };
             yield return new object[] { Status.BeingPrepared, "Your food is being prepared" };
             yield return new object[] { Status.ReadyForPickUp, "An order is ready for pickup" };
             yield return new object[] { Status.PickedUp, "Your order has been picked up" };


### PR DESCRIPTION
#5 
This PR aims to add a Rejected status to the order statuses, so the customer can see if it was rejected. The customer still won't actually *receive* an order status update, but they can check it themselves.